### PR TITLE
Output color in RGB instead of sRGB

### DIFF
--- a/MetalSplatter/Resources/Shaders.metal
+++ b/MetalSplatter/Resources/Shaders.metal
@@ -49,6 +49,10 @@ typedef struct
     float4 color;
 } ColorInOut;
 
+float4 decodeGamma(float4 v) {
+    return float4(pow(v.rgb, float3(2.2)), v.a);
+}
+
 float3x3 quaternionToMatrix(float4 quaternion) {
     float3x3 rotationMatrix;
     rotationMatrix[0] = {
@@ -213,7 +217,8 @@ vertex ColorInOut splatVertexShader(uint vertexID [[vertex_id]],
 
     out.position = float4(screenVertex.x, screenVertex.y, 0, 1);
     out.textureCoordinates = textureCoordinates;
-    out.color = splat.color;
+    // the color here is in gamma space, so bring it to linear
+    out.color = decodeGamma(splat.color);
     return out;
 }
 


### PR DESCRIPTION
The color output from shader is in gamma space, so we need to bring it to linear, to align with the output texture.

Before:

![Screenshot 2024-02-05 at 14 09 12](https://github.com/scier/MetalSplatter/assets/11192474/76036a2c-66b4-4794-9c6f-53c21f106c77)

After:
![Screenshot 2024-02-05 at 14 08 34](https://github.com/scier/MetalSplatter/assets/11192474/d037c043-4686-480e-b4d6-0ce5038cdcff)