### PR TITLE
Remove normals

### DIFF
--- a/SplatIO/Sources/SplatPLYSceneReader.swift
+++ b/SplatIO/Sources/SplatPLYSceneReader.swift
@@ -44,7 +44,7 @@ private class SplatPLYSceneReaderStream {
     private var pointElementMapping: PointElementMapping?
     private var expectedPointCount: UInt32 = 0
     private var pointCount: UInt32 = 0
-    private var reusablePoint = SplatScenePoint(position: .zero, normal: .zero, color: .none, opacity: .zero, scale: .zero, rotation: .init(vector: .zero))
+    private var reusablePoint = SplatScenePoint(position: .zero, color: .none, opacity: .zero, scale: .zero, rotation: .init(vector: .zero))
 
     func read(_ ply: PLYReader, to delegate: SplatSceneReaderDelegate) {
         self.delegate = delegate
@@ -128,9 +128,6 @@ private struct PointElementMapping {
         static let positionX = [ "x" ]
         static let positionY = [ "y" ]
         static let positionZ = [ "z" ]
-        static let normalX = [ "nx", "nxx" ]
-        static let normalY = [ "ny" ]
-        static let normalZ = [ "nz" ]
         static let sh0_r = [ "f_dc_0" ]
         static let sh0_g = [ "f_dc_1" ]
         static let sh0_b = [ "f_dc_2" ]
@@ -162,9 +159,6 @@ private struct PointElementMapping {
     let positionXPropertyIndex: Int
     let positionYPropertyIndex: Int
     let positionZPropertyIndex: Int
-    let normalXPropertyIndex: Int
-    let normalYPropertyIndex: Int
-    let normalZPropertyIndex: Int
     let colorPropertyIndices: Color
     let scaleXPropertyIndex: Int
     let scaleYPropertyIndex: Int
@@ -184,9 +178,6 @@ private struct PointElementMapping {
         let positionXPropertyIndex = try headerElement.index(forFloat32PropertyNamed: PropertyName.positionX)
         let positionYPropertyIndex = try headerElement.index(forFloat32PropertyNamed: PropertyName.positionY)
         let positionZPropertyIndex = try headerElement.index(forFloat32PropertyNamed: PropertyName.positionZ)
-        let normalXPropertyIndex = try headerElement.index(forFloat32PropertyNamed: PropertyName.normalX)
-        let normalYPropertyIndex = try headerElement.index(forFloat32PropertyNamed: PropertyName.normalY)
-        let normalZPropertyIndex = try headerElement.index(forFloat32PropertyNamed: PropertyName.normalZ)
 
         let color: Color
         if let sh0_rPropertyIndex = try headerElement.index(forOptionalFloat32PropertyNamed: PropertyName.sh0_r),
@@ -234,9 +225,6 @@ private struct PointElementMapping {
                                    positionXPropertyIndex: positionXPropertyIndex,
                                    positionYPropertyIndex: positionYPropertyIndex,
                                    positionZPropertyIndex: positionZPropertyIndex,
-                                   normalXPropertyIndex: normalXPropertyIndex,
-                                   normalYPropertyIndex: normalYPropertyIndex,
-                                   normalZPropertyIndex: normalZPropertyIndex,
                                    colorPropertyIndices: color,
                                    scaleXPropertyIndex: scaleXPropertyIndex,
                                    scaleYPropertyIndex: scaleYPropertyIndex,
@@ -252,9 +240,6 @@ private struct PointElementMapping {
         result.position.x = try element.float32Value(forPropertyIndex: positionXPropertyIndex)
         result.position.y = try element.float32Value(forPropertyIndex: positionYPropertyIndex)
         result.position.z = try element.float32Value(forPropertyIndex: positionZPropertyIndex)
-        result.normal.x = try element.float32Value(forPropertyIndex: normalXPropertyIndex)
-        result.normal.y = try element.float32Value(forPropertyIndex: normalYPropertyIndex)
-        result.normal.z = try element.float32Value(forPropertyIndex: normalZPropertyIndex)
 
         switch colorPropertyIndices {
         case .sphericalHarmonic(let r, let g, let b, let sphericalHarmonicsPropertyIndices):

--- a/SplatIO/Sources/SplatScenePoint.swift
+++ b/SplatIO/Sources/SplatScenePoint.swift
@@ -22,20 +22,17 @@ public struct SplatScenePoint {
     }
 
     public var position: SIMD3<Float>
-    public var normal: SIMD3<Float>
     public var color: Color
     public var opacity: Float
     public var scale: SIMD3<Float>
     public var rotation: simd_quatf
 
     public init(position: SIMD3<Float>,
-                normal: SIMD3<Float>,
                 color: Color,
                 opacity: Float,
                 scale: SIMD3<Float>,
                 rotation: simd_quatf) {
         self.position = position
-        self.normal = normal
         self.color = color
         self.opacity = opacity
         self.scale = scale


### PR DESCRIPTION
Currently, the normals within the Gaussian splatting PLY file are set to zeros, which means they contribute no meaningful information. By removing these redundant normal vectors, we can achieve a slight performance boost.

```python
     # https://github.com/graphdeco-inria/gaussian-splatting/blob/d9fad7b3450bf4bd29316315032d57157e23a515/scene/gaussian_model.py#L195
    def save_ply(self, path):
        mkdir_p(os.path.dirname(path))

        xyz = self._xyz.detach().cpu().numpy()
        normals = np.zeros_like(xyz)
        f_dc = self._features_dc.detach().transpose(1, 2).flatten(start_dim=1).contiguous().cpu().numpy()
        f_rest = self._features_rest.detach().transpose(1, 2).flatten(start_dim=1).contiguous().cpu().numpy()
        ...
```