### PR TITLE
Feature/sort performance fixes

### DIFF
--- a/MetalSplatter/Resources/Shaders.metal
+++ b/MetalSplatter/Resources/Shaders.metal
@@ -1,5 +1,6 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
+#include <metal_math>
 
 using namespace metal;
 
@@ -162,7 +163,11 @@ vertex ColorInOut splatVertexShader(uint vertexID [[vertex_id]],
                           projectedCenter.z,
                           projectedCenter.w);
     out.relativePosition = kBoundsRadius * relativeCoordinates;
-    out.color = splat.color;
+    float gamma = 2.2;
+    out.color.rgb = pow(splat.color.rgb, half3(1.0/gamma));
+    out.color.a = splat.color.a;
+//    out.color = splat.color;
+
     return out;
 }
 

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -421,9 +421,9 @@ public class SplatRenderer {
             guard let self = self else { return }
             
             var orderAndDepthTempSort = Array(repeating: SplatIndexAndDepth(index: .max, depth: 0), count: splatCount)
-            
-            for i in 0..<splatCount {
-                orderAndDepthTempSort[i].index = UInt32(i)
+
+            (0..<splatCount).forEach {
+                orderAndDepthTempSort[$0].index = UInt32($0)
             }
             
             defer {
@@ -431,17 +431,15 @@ public class SplatRenderer {
                 onSortComplete?(-sortStartTime.timeIntervalSinceNow)
             }
 
-            DispatchQueue.concurrentPerform(iterations: splatCount) { [weak self] i in
-
-                guard let self = self else { return }
-
+            for i in 0..<splatCount
+            {
                 let index = orderAndDepthTempSort[i].index
                 let splatPosition = self.splatBuffer.values[Int(index)].position
                 let splatPositionSimd = simd_float3(x: splatPosition.x, y: splatPosition.y, z: splatPosition.z)
                 if Constants.sortByDistance {
-                    orderAndDepthTempSort[i].depth = simd_length_squared(  splatPositionSimd - cameraWorldPosition)
+                    orderAndDepthTempSort[i].depth = simd_length_squared( splatPositionSimd - cameraWorldPosition )
                 } else {
-                    orderAndDepthTempSort[i].depth = simd_dot(splatPositionSimd, cameraWorldForward)
+                    orderAndDepthTempSort[i].depth = simd_dot( splatPositionSimd, cameraWorldForward )
                 }
             }
 

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -19,6 +19,8 @@ public class SplatRenderer {
         static let sortByDistance = true
     }
 
+    private var sortQueue = DispatchQueue(label: "splatrenderer.sort-queue", qos: .userInteractive)
+    
     private static let log =
         Logger(subsystem: Bundle.module.bundleIdentifier!,
                category: "SplatRenderer")
@@ -414,7 +416,10 @@ public class SplatRenderer {
         let cameraWorldForward = cameraWorldForward
         let cameraWorldPosition = cameraWorldPosition
 
-        Task(priority: .high) {
+        self.sortQueue.async { [weak self] in
+            
+            guard let self = self else { return }
+            
             defer {
                 sorting = false
                 onSortComplete?(-sortStartTime.timeIntervalSinceNow)

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -431,14 +431,20 @@ public class SplatRenderer {
                 onSortComplete?(-sortStartTime.timeIntervalSinceNow)
             }
 
-            for i in 0..<splatCount
-            {
-                let index = orderAndDepthTempSort[i].index
-                let splatPosition = self.splatBuffer.values[Int(index)].position
-                let splatPositionSimd = simd_float3(x: splatPosition.x, y: splatPosition.y, z: splatPosition.z)
-                if Constants.sortByDistance {
+            if Constants.sortByDistance {
+                for i in 0..<splatCount
+                {
+                    let index = orderAndDepthTempSort[i].index
+                    let splatPosition = self.splatBuffer.values[Int(index)].position
+                    let splatPositionSimd = simd_float3(x: splatPosition.x, y: splatPosition.y, z: splatPosition.z)
                     orderAndDepthTempSort[i].depth = simd_length_squared( splatPositionSimd - cameraWorldPosition )
-                } else {
+                }
+            } else {
+                for i in 0..<splatCount
+                {
+                    let index = orderAndDepthTempSort[i].index
+                    let splatPosition = self.splatBuffer.values[Int(index)].position
+                    let splatPositionSimd = simd_float3(x: splatPosition.x, y: splatPosition.y, z: splatPosition.z)
                     orderAndDepthTempSort[i].depth = simd_dot( splatPositionSimd, cameraWorldForward )
                 }
             }

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -18,7 +18,7 @@ public class SplatRenderer {
         // Sort by euclidian distance squared from camera position (true), or along the "forward" vector (false)
         // TODO: compare the behaviour and performance of sortByDistance
         // notes: sortByDistance introduces unstable artifacts when you get close to an object; whereas !sortByDistance introduces artifacts are you turn -- but they're a little subtler maybe?
-        static let sortByDistance = false
+        static let sortByDistance = true
     }
 
     private var sortQueue = DispatchQueue(label: "splatrenderer.sort-queue", qos: .default)

--- a/PLYIO/Sources/PLYHeader+ascii.swift
+++ b/PLYIO/Sources/PLYHeader+ascii.swift
@@ -48,7 +48,7 @@ extension PLYHeader {
                     throw ASCIIDecodeError.headerUnknownKeyword(keywordString)
                 }
                 switch keyword {
-                case .ply, .comment:
+                case .ply, .comment, .obj_info:
                     return
                 case .format:
                     guard header == nil else {

--- a/PLYIO/Sources/PLYHeader.swift
+++ b/PLYIO/Sources/PLYHeader.swift
@@ -8,6 +8,7 @@ public struct PLYHeader: Equatable {
         case element = "element"
         case property = "property"
         case endHeader = "end_header"
+        case obj_info = "obj_info"
     }
 
     public enum Format: String, Equatable {


### PR DESCRIPTION
Hi! Thanks for this library, it's been awesome to work with! 

I made some minor tweaks related to sorting which got me some higher FPS ~~at the cost of some additional CPU churn~~

* replaced the swift async task call with a dedicated dispatch queue
* added some vdsp math to some areas of interest
* ~~added a dispatch concurrentPerform on embarrassingly parallel loop that only worked in place~~
  * It actually turns out I was over subscribing GCD here and just using an in place iteration was faster- turns out this can run at 120Hz w/o extra CPU usage. 
* cleaned up some memory semantics to allow for parallelization on the CPU  (re-allocation)

This took a sample splat prior from 80fps in my macOS metal app on an M1 Max 64 Gb to 120 FPS

Things that could make a large difference I haven't gotten to yet

* floating point radix sort on the depth rather than swift which should be faster
* In theory could even do GPU sorting but yeeeaaahhh