### PR TITLE
Drop instance rendering, embrace indexed rendering

### DIFF
--- a/MetalSplatter/Resources/Shaders.metal
+++ b/MetalSplatter/Resources/Shaders.metal
@@ -117,7 +117,6 @@ void decomposeCovariance(float3 cov2D, thread float2 &v1, thread float2 &v2) {
 }
 
 vertex ColorInOut splatVertexShader(uint vertexID [[vertex_id]],
-                                    uint instanceID [[instance_id]],
                                     ushort amp_id [[amplification_id]],
                                     constant Splat* splatArray [[ buffer(BufferIndexSplat) ]],
                                     constant UniformsArray & uniformsArray [[ buffer(BufferIndexUniforms) ]]) {
@@ -125,7 +124,7 @@ vertex ColorInOut splatVertexShader(uint vertexID [[vertex_id]],
 
     Uniforms uniforms = uniformsArray.uniforms[min(int(amp_id), kMaxViewCount)];
 
-    Splat splat = splatArray[instanceID];
+    Splat splat = splatArray[vertexID / 4];
     float4 viewPosition4 = uniforms.viewMatrix * float4(splat.position, 1);
     float3 viewPosition3 = viewPosition4.xyz;
 
@@ -149,7 +148,7 @@ vertex ColorInOut splatVertexShader(uint vertexID [[vertex_id]],
     }
 
     const half2 relativeCoordinatesArray[] = { { -1, -1 }, { -1, 1 }, { 1, -1 }, { 1, 1 } };
-    half2 relativeCoordinates = relativeCoordinatesArray[vertexID];
+    half2 relativeCoordinates = relativeCoordinatesArray[vertexID % 4];
     half2 screenSizeFloat = half2(uniforms.screenSize.x, uniforms.screenSize.y);
     half2 projectedScreenDelta =
         (relativeCoordinates.x * half2(axis1) + relativeCoordinates.y * half2(axis2))

--- a/MetalSplatter/Sources/SplatRenderer.swift
+++ b/MetalSplatter/Sources/SplatRenderer.swift
@@ -382,7 +382,7 @@ public class SplatRenderer {
 
         let indexCount = splatBuffer.count * 6
         let indexBuffer = self.indexBuffer ?? device.makeBuffer(length: indexCount * MemoryLayout<UInt32>.size)!
-        if indexBuffer == nil {
+        if self.indexBuffer == nil {
             let uint32Buffer = indexBuffer.contents().assumingMemoryBound(to: UInt32.self)
             for i in 0..<splatBuffer.count {
                 uint32Buffer[i * 6 + 0] = UInt32(i * 4 + 0)


### PR DESCRIPTION
TIL that instance rendering was not very well-optimized in most GPU drivers.

So I tried to use indexed rendering instead, and noticed **~20% frame rate improvement** on my M1 MacBook Air.

### Before

<img width="1075" alt="Screenshot 2024-07-23 at 23 41 03" src="https://github.com/user-attachments/assets/b57f1105-5b36-47f0-ac5c-455fcb820faa">

### After

<img width="1075" alt="Screenshot 2024-07-23 at 23 44 03" src="https://github.com/user-attachments/assets/4cd546d1-01ab-40bb-9d82-3088e853c920">