### PR TITLE
correctly use projectedCenter.z to discard splats

### DIFF
--- a/MetalSplatter/Resources/Shaders.metal
+++ b/MetalSplatter/Resources/Shaders.metal
@@ -139,7 +139,8 @@ vertex ColorInOut splatVertexShader(uint vertexID [[vertex_id]],
     float4 projectedCenter = uniforms.projectionMatrix * viewPosition4;
 
     float bounds = 1.2 * projectedCenter.w;
-    if (projectedCenter.z < -projectedCenter.w ||
+    if (projectedCenter.z < 0.0 ||
+        projectedCenter.z > projectedCenter.w ||
         projectedCenter.x < -bounds ||
         projectedCenter.x > bounds ||
         projectedCenter.y < -bounds ||


### PR DESCRIPTION
**correctly use projectedCenter.z to discard splats out outside the view frustum**

At

https://github.com/scier/MetalSplatter/blob/9e0fae2e7a0895fd4b21ab82e1ccfb03a0f0aa8c/SampleApp/Scene/MetalKitSceneRenderer.swift#L65-L69

, you set `nearZ` to `0.1` and `farZ` to `100.0`.

According to

https://github.com/scier/MetalSplatter/blob/9e0fae2e7a0895fd4b21ab82e1ccfb03a0f0aa8c/SampleApp/Util/MatrixMathUtil.swift#L24-L32

and

https://github.com/scier/MetalSplatter/blob/9e0fae2e7a0895fd4b21ab82e1ccfb03a0f0aa8c/MetalSplatter/Resources/Shaders.metal#L139

- when `z == -nearZ`, `projectedCenter.z / projectedCenter.w == 0.0`
- when `z == -farZ`, `projectedCenter.z / projectedCenter.w == 1.0`

So if you want to discard splats out of the given range, you should use `projectedCenter.z < 0.0 || projectedCenter.z > projectedCenter.w` instead of `projectedCenter.z < -projectedCenter.w`.

https://github.com/scier/MetalSplatter/blob/9e0fae2e7a0895fd4b21ab82e1ccfb03a0f0aa8c/MetalSplatter/Resources/Shaders.metal#L142-L149
