### PR TITLE
Add SPZ file format support and related functionality

### DIFF
--- a/MetalSplatter/Sources/MPSArgSort.swift
+++ b/MetalSplatter/Sources/MPSArgSort.swift
@@ -1,0 +1,68 @@
+//  Original source: https://gist.github.com/kemchenj/26e1dad40e5b89de2828bad36c81302f
+//  Assessed Feb 2, 2025.
+import MetalPerformanceShaders
+import MetalPerformanceShadersGraph
+
+public class MPSArgSort {
+  private let dataType: MPSDataType
+  private let graph: MPSGraph
+  private let graphExecutable: MPSGraphExecutable
+  private let inputTensor: MPSGraphTensor
+  private let outputTensor: MPSGraphTensor
+
+  init(dataType: MPSDataType, descending: Bool = false) {
+    self.dataType = dataType
+
+    let graph = MPSGraph()
+    let inputTensor = graph.placeholder(shape: nil, dataType: dataType, name: nil)
+    let outputTensor = graph.argSort(inputTensor, axis: 0, descending: descending, name: nil)
+
+    self.graph = graph
+    self.inputTensor = inputTensor
+    self.outputTensor = outputTensor
+    self.graphExecutable = autoreleasepool {
+      let compilationDescriptor = MPSGraphCompilationDescriptor()
+      compilationDescriptor.waitForCompilationCompletion = true
+      compilationDescriptor.disableTypeInference()
+      return graph.compile(with: nil,
+                           feeds: [inputTensor : MPSGraphShapedType(shape: nil, dataType: dataType)],
+                           targetTensors: [outputTensor],
+                           targetOperations: nil,
+                           compilationDescriptor: compilationDescriptor)
+    }
+  }
+
+  func callAsFunction(
+    commandQueue: any MTLCommandQueue,
+    input: any MTLBuffer,
+    output: any MTLBuffer,
+    count: Int
+  ) {
+    autoreleasepool {
+      let commandBuffer = commandQueue.makeCommandBuffer()!
+      callAsFunction(commandBuffer: commandBuffer,
+                     input: input,
+                     output: output,
+                     count: count)
+      assert(commandBuffer.error == nil)
+      assert(commandBuffer.status == .completed)
+    }
+  }
+
+  private func callAsFunction(
+    commandBuffer: any MTLCommandBuffer,
+    input: any MTLBuffer,
+    output: any MTLBuffer,
+    count: Int
+  ) {
+    let shape: [NSNumber] = [count as NSNumber]
+    let inputData = MPSGraphTensorData(input, shape: shape, dataType: dataType)
+    let outputData = MPSGraphTensorData(output, shape: shape, dataType: .int32)
+    let executionDescriptor = MPSGraphExecutableExecutionDescriptor()
+    executionDescriptor.waitUntilCompleted = true
+    graphExecutable.encode(to: MPSCommandBuffer(commandBuffer: commandBuffer),
+                           inputs: [inputData],
+                           results: [outputData],
+                           executionDescriptor: executionDescriptor)
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,10 @@ let package = Package(
             targets: [ "PLYIO" ]
         ),
         .library(
+            name: "SPZIO",
+            targets: [ "SPZIO" ]
+        ),
+        .library(
             name: "SplatIO",
             targets: [ "SplatIO" ]
         ),
@@ -48,8 +52,21 @@ let package = Package(
             resources: [ .copy("TestData") ]
         ),
         .target(
+            name: "SPZIO",
+            path: "SPZIO",
+            sources: [ "Sources" ],
+            publicHeadersPath: "Sources/include",
+            cxxSettings: [
+                .headerSearchPath("Sources/cpp"),
+                .unsafeFlags(["-std=c++17"]),
+            ],
+            linkerSettings: [
+                .linkedLibrary("z")
+            ]
+        ),
+        .target(
             name: "SplatIO",
-            dependencies: [ "PLYIO" ],
+            dependencies: [ "PLYIO", "SPZIO" ],
             path: "SplatIO",
             sources: [ "Sources" ]
         ),

--- a/SPZIO/Sources/SPZReader.mm
+++ b/SPZIO/Sources/SPZReader.mm
@@ -1,0 +1,132 @@
+#import "include/SPZReader.h"
+#include "cpp/load-spz.h"
+#include "cpp/splat-types.h"
+#include <vector>
+
+static NSString * const SPZReaderErrorDomain = @"com.metalsplatter.spzio";
+
+typedef NS_ENUM(NSInteger, SPZReaderErrorCode) {
+    SPZReaderErrorCodeFileReadFailed = 1,
+    SPZReaderErrorCodeInvalidData = 2,
+    SPZReaderErrorCodeNoPoints = 3,
+};
+
+@implementation SPZReader
+
++ (BOOL)loadSPZFileAtURL:(NSURL *)url
+         batchHandler:(SPZPointBatchHandler)handler
+                error:(NSError **)error {
+    // Load file into memory
+    NSData *data = [NSData dataWithContentsOfURL:url options:0 error:error];
+    if (!data) {
+        return NO;
+    }
+
+    return [self loadSPZData:data batchHandler:handler error:error];
+}
+
++ (BOOL)loadSPZData:(NSData *)data
+       batchHandler:(SPZPointBatchHandler)handler
+              error:(NSError **)error {
+    if (!data || data.length == 0) {
+        if (error) {
+            *error = [NSError errorWithDomain:SPZReaderErrorDomain
+                                         code:SPZReaderErrorCodeInvalidData
+                                     userInfo:@{NSLocalizedDescriptionKey: @"Invalid or empty SPZ data"}];
+        }
+        return NO;
+    }
+
+    // Load the SPZ file using the C++ library
+    // SPZ internally uses RUB coordinate system
+    spz::UnpackOptions options;
+    options.to = spz::CoordinateSystem::RUB;
+
+    const uint8_t *bytes = static_cast<const uint8_t *>(data.bytes);
+    spz::GaussianCloud cloud = spz::loadSpz(bytes, (int32_t)data.length, options);
+
+    if (cloud.numPoints == 0) {
+        if (error) {
+            *error = [NSError errorWithDomain:SPZReaderErrorDomain
+                                         code:SPZReaderErrorCodeNoPoints
+                                     userInfo:@{NSLocalizedDescriptionKey: @"SPZ file contains no points or failed to load"}];
+        }
+        return NO;
+    }
+
+    // Convert to our point structure and send in batches
+    const size_t batchSize = 1024;
+    std::vector<SPZGaussianPoint> batch;
+    batch.reserve(batchSize);
+
+    for (int32_t i = 0; i < cloud.numPoints; i++) {
+        SPZGaussianPoint point;
+
+        // Position
+        point.position = simd_make_float3(
+            cloud.positions[i * 3 + 0],
+            cloud.positions[i * 3 + 1],
+            cloud.positions[i * 3 + 2]
+        );
+
+        // Rotation (quaternion: w, x, y, z)
+        point.rotation = simd_make_float4(
+            cloud.rotations[i * 4 + 0], // w
+            cloud.rotations[i * 4 + 1], // x
+            cloud.rotations[i * 4 + 2], // y
+            cloud.rotations[i * 4 + 3]  // z
+        );
+
+        // Scale (log scale)
+        point.scale = simd_make_float3(
+            cloud.scales[i * 3 + 0],
+            cloud.scales[i * 3 + 1],
+            cloud.scales[i * 3 + 2]
+        );
+
+        // Color (SH DC component)
+        point.color = simd_make_float3(
+            cloud.colors[i * 3 + 0],
+            cloud.colors[i * 3 + 1],
+            cloud.colors[i * 3 + 2]
+        );
+
+        // Alpha (logit)
+        point.alpha = cloud.alphas[i];
+
+        // SH degree
+        point.shDegree = cloud.shDegree;
+
+        batch.push_back(point);
+
+        // Send batch when full
+        if (batch.size() >= batchSize) {
+            handler(batch.data(), batch.size());
+            batch.clear();
+        }
+    }
+
+    // Send remaining points
+    if (!batch.empty()) {
+        handler(batch.data(), batch.size());
+    }
+
+    return YES;
+}
+
++ (NSUInteger)pointCountInFileAtURL:(NSURL *)url error:(NSError **)error {
+    NSData *data = [NSData dataWithContentsOfURL:url options:0 error:error];
+    if (!data) {
+        return 0;
+    }
+
+    spz::UnpackOptions options;
+    options.to = spz::CoordinateSystem::RUB;
+
+    const uint8_t *bytes = static_cast<const uint8_t *>(data.bytes);
+    spz::GaussianCloud cloud = spz::loadSpz(bytes, (int32_t)data.length, options);
+
+    return cloud.numPoints;
+}
+
+@end

--- a/SPZIO/Sources/cpp/load-spz.cc
+++ b/SPZIO/Sources/cpp/load-spz.cc
@@ -1,0 +1,936 @@
+#include "load-spz.h"
+
+#include <zlib.h>
+
+#ifdef ANDROID
+#include <android/log.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+#include <vector>
+
+namespace spz {
+
+namespace {
+
+#ifdef ANDROID
+static constexpr char LOG_TAG[] = "SPZ";
+template <class... Args>
+static void SpzLog(const char *fmt, Args &&...args) {
+  __android_log_print(ANDROID_LOG_INFO, LOG_TAG, fmt, std::forward<Args>(args)...);
+}
+#else
+template <class... Args>
+static void SpzLog(const char *fmt, Args &&...args) {
+  printf(fmt, std::forward<Args>(args)...);
+  printf("\n");
+  fflush(stdout);
+}
+#endif  // ANDROID
+
+template <class... Args>
+static void SpzLog(const char *fmt) {
+  SpzLog("%s", fmt);
+}
+
+// Scale factor for DC color components. To convert to RGB, we should multiply by 0.282, but it can
+// be useful to represent base colors that are out of range if the higher spherical harmonics bands
+// bring them back into range so we multiply by a smaller value.
+constexpr float colorScale = 0.15f;
+constexpr float sqrt1_2 = (float)0.707106781186547524401; // 1/sqrt(2)
+
+int32_t degreeForDim(int32_t dim) {
+  if (dim < 3)
+    return 0;
+  if (dim < 8)
+    return 1;
+  if (dim < 15)
+    return 2;
+  return 3;
+}
+
+int32_t dimForDegree(int32_t degree) {
+  switch (degree) {
+    case 0:
+      return 0;
+    case 1:
+      return 3;
+    case 2:
+      return 8;
+    case 3:
+      return 15;
+    default:
+      SpzLog("[SPZ: ERROR] Unsupported SH degree: %d\n", degree);
+      return 0;
+  }
+}
+
+uint8_t toUint8(float x) { return static_cast<uint8_t>(std::clamp(std::round(x), 0.0f, 255.0f)); }
+
+// Quantizes to 8 bits, the round to nearest bucket center. 0 always maps to a bucket center.
+uint8_t quantizeSH(float x, int32_t bucketSize) {
+  int32_t q = static_cast<int>(std::round(x * 128.0f) + 128.0f);
+  q = (q + bucketSize / 2) / bucketSize * bucketSize;
+  return static_cast<uint8_t>(std::clamp(q, 0, 255));
+}
+
+float unquantizeSH(uint8_t x) { return (static_cast<float>(x) - 128.0f) / 128.0f; }
+
+float sigmoid(float x) { return 1 / (1 + std::exp(-x)); }
+
+float invSigmoid(float x) { return std::log(x / (1.0f - x)); }
+
+template <typename T>
+size_t countBytes(std::vector<T> vec) {
+  return vec.size() * sizeof(vec[0]);
+}
+
+#define CHECK(x)                                                              \
+  {                                                                           \
+    if (!(x)) {                                                               \
+      SpzLog("[SPZ: ERROR] Check failed: %s:%d: %s", __FILE__, __LINE__, #x); \
+      return false;                                                           \
+    }                                                                         \
+  }
+
+#define CHECK_GE(x, y) CHECK((x) >= (y))
+#define CHECK_LE(x, y) CHECK((x) <= (y))
+#define CHECK_EQ(x, y) CHECK((x) == (y))
+
+bool checkSizes(const GaussianCloud &g) {
+  CHECK_GE(g.numPoints, 0);
+  CHECK_GE(g.shDegree, 0);
+  CHECK_LE(g.shDegree, 3);
+  CHECK_EQ(g.positions.size(), g.numPoints * 3);
+  CHECK_EQ(g.scales.size(), g.numPoints * 3);
+  CHECK_EQ(g.rotations.size(), g.numPoints * 4);
+  CHECK_EQ(g.alphas.size(), g.numPoints);
+  CHECK_EQ(g.colors.size(), g.numPoints * 3);
+  CHECK_EQ(g.sh.size(), g.numPoints * dimForDegree(g.shDegree) * 3);
+  return true;
+}
+
+bool checkSizes(const PackedGaussians &packed, int32_t numPoints, int32_t shDim, bool usesFloat16) {
+  CHECK_EQ(packed.positions.size(), numPoints * 3 * (usesFloat16 ? 2 : 3));
+  CHECK_EQ(packed.scales.size(), numPoints * 3);
+  CHECK_EQ(packed.rotations.size(), numPoints * (packed.usesQuaternionSmallestThree ? 4 : 3));
+  CHECK_EQ(packed.alphas.size(), numPoints);
+  CHECK_EQ(packed.colors.size(), numPoints * 3);
+  CHECK_EQ(packed.sh.size(), numPoints * shDim * 3);
+  return true;
+}
+
+constexpr uint8_t FlagAntialiased = 0x1;
+
+struct PackedGaussiansHeader {
+  uint32_t magic = 0x5053474e;  // NGSP = Niantic gaussian splat
+  uint32_t version = 3;
+  uint32_t numPoints = 0;
+  uint8_t shDegree = 0;
+  uint8_t fractionalBits = 0;
+  uint8_t flags = 0;
+  uint8_t reserved = 0;
+};
+
+bool decompressGzippedImpl(
+  const uint8_t *compressed, size_t size, int32_t windowSize, std::vector<uint8_t> *out) {
+  std::vector<uint8_t> buffer(8192);
+  z_stream stream = {};
+  stream.next_in = const_cast<Bytef *>(compressed);
+  stream.avail_in = size;
+  if (inflateInit2(&stream, windowSize) != Z_OK) {
+    return false;
+  }
+  out->clear();
+  bool success = false;
+  while (true) {
+    stream.next_out = buffer.data();
+    stream.avail_out = buffer.size();
+    int32_t res = inflate(&stream, Z_NO_FLUSH);
+    if (res != Z_OK && res != Z_STREAM_END) {
+      break;
+    }
+    out->insert(out->end(), buffer.data(), buffer.data() + buffer.size() - stream.avail_out);
+    if (res == Z_STREAM_END) {
+      success = true;
+      break;
+    }
+  }
+  inflateEnd(&stream);
+  return success;
+}
+
+bool decompressGzipped(const uint8_t *compressed, size_t size, std::vector<uint8_t> *out) {
+  // Here 16 means enable automatic gzip header detection; consider switching this to 32 to enable
+  // both automated gzip and zlib header detection.
+  return decompressGzippedImpl(compressed, size, 16 | MAX_WBITS, out);
+}
+
+bool decompressGzipped(const uint8_t *compressed, size_t size, std::string *out) {
+  std::vector<uint8_t> buffer;
+  if (!decompressGzipped(compressed, size, &buffer)) {
+    return false;
+  }
+  out->assign(reinterpret_cast<const char *>(buffer.data()), buffer.size());
+  return true;
+}
+
+}  // namespace
+
+bool compressGzipped(const uint8_t *data, size_t size, std::vector<uint8_t> *out) {
+  std::vector<uint8_t> buffer(8192);
+  z_stream stream = {};
+  if (
+    deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 16 + MAX_WBITS, 9, Z_DEFAULT_STRATEGY)
+    != Z_OK) {
+    return false;
+  }
+  out->clear();
+  out->reserve(size / 4);
+  stream.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
+  stream.avail_in = size;
+  bool success = false;
+  while (true) {
+    stream.next_out = buffer.data();
+    stream.avail_out = buffer.size();
+    int32_t res = deflate(&stream, Z_FINISH);
+    if (res != Z_OK && res != Z_STREAM_END) {
+      break;
+    }
+    out->insert(out->end(), buffer.data(), buffer.data() + buffer.size() - stream.avail_out);
+    if (res == Z_STREAM_END) {
+      success = true;
+      break;
+    }
+  }
+  deflateEnd(&stream);
+  return success;
+}
+
+void packQuaternionSmallestThree(uint8_t r[4], const float rotation[4], const CoordinateConverter& c) {
+  // Normalize the quaternion
+  Quat4f q = normalized(quat4f(&rotation[0]));
+  q[0] *= c.flipQ[0];
+  q[1] *= c.flipQ[1];
+  q[2] *= c.flipQ[2];
+
+  // Find largest component
+  unsigned iLargest = 0;
+  for (unsigned i = 1; i < 4; ++i)
+  {
+    if (std::abs(q[i]) > std::abs(q[iLargest]))
+    {
+      iLargest = i;
+    }
+  }
+
+  // since -q represents the same rotation as q, transform the quaternion so the largest element
+  // is positive. This avoids having to send its sign bit.
+  unsigned negate = q[iLargest] < 0;
+
+  // Do compression using sign bit and 9-bit precision per element.
+  uint32_t comp = iLargest;
+  for (unsigned i = 0; i < 4; ++i)
+  {
+      if (i != iLargest)
+      {
+          uint32_t negbit = (q[i] < 0) ^ negate;
+          uint32_t mag =
+              (uint32_t)(float((1u << 9u) - 1u) * (std::fabs(q[i]) / sqrt1_2) + 0.5f);
+          comp = (comp << 10u) | (negbit << 9u) | mag;
+      }
+  }
+
+  // Ensure little-endianness on all platforms
+  r[0] = comp & 0xff;
+  r[1] = (comp >> 8) & 0xff;
+  r[2] = (comp >> 16) & 0xff;
+  r[3] = (comp >> 24) & 0xff;
+}
+
+PackedGaussians packGaussians(const GaussianCloud &g, const PackOptions &o) {
+  if (!checkSizes(g)) {
+    return {};
+  }
+  const int32_t numPoints = g.numPoints;
+  const int32_t shDim = dimForDegree(g.shDegree);
+  CoordinateConverter c = coordinateConverter(o.from, CoordinateSystem::RUB);
+
+  // Use 12 bits for the fractional part of coordinates (~0.25 millimeter resolution). In the future
+  // we can use different values on a per-splat basis and still be compatible with the decoder.
+  PackedGaussians packed;
+  packed.numPoints = g.numPoints;
+  packed.shDegree = g.shDegree;
+  packed.fractionalBits = 12;
+  packed.antialiased = g.antialiased;
+  packed.usesQuaternionSmallestThree = true;
+  packed.positions.resize(numPoints * 3 * 3);
+  packed.scales.resize(numPoints * 3);
+  packed.rotations.resize(numPoints * 4);
+  packed.alphas.resize(numPoints);
+  packed.colors.resize(numPoints * 3);
+  packed.sh.resize(numPoints * shDim * 3);
+
+  // Store coordinates as 24-bit fixed point values.
+  const float scale = (1 << packed.fractionalBits);
+  for (size_t i = 0; i < numPoints * 3; i++) {
+    const int32_t fixed32 =
+      static_cast<int32_t>(std::round(c.flipP[i % 3] * g.positions[i] * scale));
+    packed.positions[i * 3 + 0] = fixed32 & 0xff;
+    packed.positions[i * 3 + 1] = (fixed32 >> 8) & 0xff;
+    packed.positions[i * 3 + 2] = (fixed32 >> 16) & 0xff;
+  }
+
+  for (size_t i = 0; i < numPoints * 3; i++) {
+    packed.scales[i] = toUint8((g.scales[i] + 10.0f) * 16.0f);
+  }
+
+  for (size_t i = 0; i < numPoints; i++)
+  {
+    packQuaternionSmallestThree(&packed.rotations[4 * i], &g.rotations[4 * i], c);
+  }
+
+  for (size_t i = 0; i < numPoints; i++) {
+    // Apply sigmoid activation to alpha
+    packed.alphas[i] = toUint8(sigmoid(g.alphas[i]) * 255.0f);
+  }
+
+  for (size_t i = 0; i < numPoints * 3; i++) {
+    // Convert SH DC component to wide RGB (allowing values that are a bit above 1 and below 0).
+    packed.colors[i] = toUint8(g.colors[i] * (colorScale * 255.0f) + (0.5f * 255.0f));
+  }
+
+  if (g.shDegree > 0) {
+    // Spherical harmonics quantization parameters. The data format uses 8 bits per coefficient, but
+    // when packing, we can quantize to fewer bits for better compression.
+    constexpr int32_t sh1Bits = 5;
+    constexpr int32_t shRestBits = 4;
+    const int32_t shPerPoint = dimForDegree(g.shDegree) * 3;
+    for (size_t i = 0; i < numPoints * shPerPoint; i += shPerPoint) {
+      size_t j = 0, k = 0;
+      for (; j < 9; j += 3, k++) {  // There are 9 (3 * 3) coefficients for degree 1
+        packed.sh[i + j + 0] = quantizeSH(c.flipSh[k] * g.sh[i + j + 0], 1 << (8 - sh1Bits));
+        packed.sh[i + j + 1] = quantizeSH(c.flipSh[k] * g.sh[i + j + 1], 1 << (8 - sh1Bits));
+        packed.sh[i + j + 2] = quantizeSH(c.flipSh[k] * g.sh[i + j + 2], 1 << (8 - sh1Bits));
+      }
+      for (; j < shPerPoint; j += 3, k++) {
+        packed.sh[i + j + 0] = quantizeSH(c.flipSh[k] * g.sh[i + j + 0], 1 << (8 - shRestBits));
+        packed.sh[i + j + 1] = quantizeSH(c.flipSh[k] * g.sh[i + j + 1], 1 << (8 - shRestBits));
+        packed.sh[i + j + 2] = quantizeSH(c.flipSh[k] * g.sh[i + j + 2], 1 << (8 - shRestBits));
+      }
+    }
+  }
+
+  return packed;
+}
+
+void unpackQuaternionFirstThree(float rotation[4], const uint8_t r[3], const CoordinateConverter& c = CoordinateConverter())
+{
+  Vec3f xyz = times(
+    plus(
+      times(
+        Vec3f{ static_cast<float>(r[0]), static_cast<float>(r[1]), static_cast<float>(r[2]) },
+        1.0f / 127.5f),
+      Vec3f{ -1, -1, -1 }),
+    c.flipQ);
+  std::copy(xyz.data(), xyz.data() + 3, &rotation[0]);
+  // Compute the real component - we know the quaternion is normalized and w is non-negative
+  rotation[3] = std::sqrt(std::max(0.0f, 1.0f - squaredNorm(xyz)));
+}
+
+void unpackQuaternionSmallestThree(float rotation[4], const uint8_t r[4], const CoordinateConverter& c = CoordinateConverter())
+{
+  uint32_t comp =
+    r[0] +
+    (r[1] << 8) +
+    (r[2] << 16) +
+    (r[3] << 24);
+
+  constexpr uint32_t c_mask = (1u << 9u) - 1u;
+
+  const int i_largest = comp >> 30;
+  float sum_squares = 0;
+  // [unroll]
+  for (int i = 3; i >= 0; --i)
+  {
+    if (i != i_largest)
+    {
+      uint32_t mag    = comp & c_mask;
+      uint32_t negbit = (comp >> 9u) & 0x1u;
+      comp            = comp >> 10u;
+      rotation[i]     = sqrt1_2 * ((float)mag) / float(c_mask);
+      if (negbit == 1)
+      {
+        rotation[i] = -rotation[i];
+      }
+      sum_squares += rotation[i] * rotation[i];
+    }
+  }
+  rotation[i_largest] = sqrt(1.0f - sum_squares);
+
+  for (int i = 0; i < 3; i++)
+  {
+    rotation[i] *= c.flipQ[i];
+  }
+}
+
+UnpackedGaussian PackedGaussian::unpack(
+  bool usesFloat16, bool usesQuaternionSmallestThree, int32_t fractionalBits, const CoordinateConverter &c) const {
+  UnpackedGaussian result;
+  if (usesFloat16) {
+    // Decode legacy float16 format. We can remove this at some point as it was never released.
+    const auto *halfData = reinterpret_cast<const Half *>(position.data());
+    for (size_t i = 0; i < 3; i++) {
+      result.position[i] = c.flipP[i] * halfToFloat(halfData[i]);
+    }
+  } else {
+    // Decode 24-bit fixed point coordinates
+    float scale = 1.0 / (1 << fractionalBits);
+    for (size_t i = 0; i < 3; i++) {
+      int32_t fixed32 = position[i * 3 + 0];
+      fixed32 |= position[i * 3 + 1] << 8;
+      fixed32 |= position[i * 3 + 2] << 16;
+      fixed32 |= (fixed32 & 0x800000) ? 0xff000000 : 0;  // sign extension
+      result.position[i] = c.flipP[i] * static_cast<float>(fixed32) * scale;
+    }
+  }
+
+  for (size_t i = 0; i < 3; i++) {
+    result.scale[i] = (scale[i] / 16.0f - 10.0f);
+  }
+
+  if (usesQuaternionSmallestThree)
+  {
+      unpackQuaternionSmallestThree(&result.rotation[0], &rotation[0], c);
+  }
+  else
+  {
+      unpackQuaternionFirstThree(&result.rotation[0], &rotation[0], c);
+  }
+
+  result.alpha = invSigmoid(alpha / 255.0f);
+
+  for (size_t i = 0; i < 3; i++) {
+    result.color[i] = ((color[i] / 255.0f) - 0.5f) / colorScale;
+  }
+
+  for (size_t i = 0; i < 15; i++) {
+    result.shR[i] = c.flipSh[i] * unquantizeSH(shR[i]);
+    result.shG[i] = c.flipSh[i] * unquantizeSH(shG[i]);
+    result.shB[i] = c.flipSh[i] * unquantizeSH(shB[i]);
+  }
+
+  return result;
+}
+
+PackedGaussian PackedGaussians::at(int32_t i) const {
+  PackedGaussian result;
+  int32_t positionBytes = usesFloat16() ? 6 : 9;
+  int32_t start3 = i * 3;
+  const auto *p = &positions[i * positionBytes];
+  std::copy(p, p + positionBytes, result.position.data());
+  std::copy(&scales[start3], &scales[start3] + 3, result.scale.data());
+  int32_t rotationBytes = usesQuaternionSmallestThree ? 4 : 3;
+  const auto& r = &rotations[i * rotationBytes];
+  std::copy(r, r + rotationBytes, result.rotation.data());
+  std::copy(&colors[start3], &colors[start3] + 3, result.color.data());
+  result.alpha = alphas[i];
+
+  int32_t shDim = dimForDegree(shDegree);
+  const auto *sh = &this->sh[i * shDim * 3];
+  for (int32_t j = 0; j < shDim; ++j, sh += 3) {
+    result.shR[j] = sh[0];
+    result.shG[j] = sh[1];
+    result.shB[j] = sh[2];
+  }
+  for (int32_t j = shDim; j < 15; ++j) {
+    result.shR[j] = 128;
+    result.shG[j] = 128;
+    result.shB[j] = 128;
+  }
+
+  return result;
+}
+
+UnpackedGaussian PackedGaussians::unpack(int32_t i, const CoordinateConverter &c) const {
+  return at(i).unpack(usesFloat16(), usesQuaternionSmallestThree, fractionalBits, c);
+}
+
+bool PackedGaussians::usesFloat16() const { return positions.size() == numPoints * 3 * 2; }
+
+GaussianCloud unpackGaussians(const PackedGaussians &packed, const UnpackOptions &o) {
+  const int32_t numPoints = packed.numPoints;
+  const int32_t shDim = dimForDegree(packed.shDegree);
+  const bool usesFloat16 = packed.usesFloat16();
+  const bool usesQuaternionSmallestThree = packed.usesQuaternionSmallestThree;
+  if (!checkSizes(packed, numPoints, shDim, usesFloat16)) {
+    return {};
+  }
+
+  GaussianCloud result;
+  result.numPoints = packed.numPoints;
+  result.shDegree = packed.shDegree;
+  result.antialiased = packed.antialiased;
+  result.positions.resize(numPoints * 3);
+  result.scales.resize(numPoints * 3);
+  result.rotations.resize(numPoints * 4);
+  result.alphas.resize(numPoints);
+  result.colors.resize(numPoints * 3);
+  result.sh.resize(numPoints * shDim * 3);
+
+  if (usesFloat16) {
+    // Decode legacy float16 format. We can remove this at some point as it was never released.
+    const auto *halfData = reinterpret_cast<const Half *>(packed.positions.data());
+    for (size_t i = 0; i < numPoints * 3; i++) {
+      result.positions[i] = halfToFloat(halfData[i]);
+    }
+  } else {
+    // Decode 24-bit fixed point coordinates
+    float scale = 1.0 / (1 << packed.fractionalBits);
+    for (size_t i = 0; i < numPoints * 3; i++) {
+      int32_t fixed32 = packed.positions[i * 3 + 0];
+      fixed32 |= packed.positions[i * 3 + 1] << 8;
+      fixed32 |= packed.positions[i * 3 + 2] << 16;
+      fixed32 |= (fixed32 & 0x800000) ? 0xff000000 : 0;  // sign extension
+      result.positions[i] = static_cast<float>(fixed32) * scale;
+    }
+  }
+
+  for (size_t i = 0; i < numPoints * 3; i++) {
+    result.scales[i] = packed.scales[i] / 16.0f - 10.0f;
+  }
+
+  for (size_t i = 0; i < numPoints; i++) {
+    if (usesQuaternionSmallestThree) {
+      unpackQuaternionSmallestThree(&result.rotations[4 * i], &packed.rotations[4 * i]);
+    } else {
+      unpackQuaternionFirstThree(&result.rotations[4 * i], &packed.rotations[3 * i]);
+    }
+  }
+
+  for (size_t i = 0; i < numPoints; i++) {
+    result.alphas[i] = invSigmoid(packed.alphas[i] / 255.0f);
+  }
+
+  for (size_t i = 0; i < numPoints * 3; i++) {
+    result.colors[i] = ((packed.colors[i] / 255.0f) - 0.5f) / colorScale;
+  }
+
+  for (size_t i = 0; i < packed.sh.size(); i++) {
+    result.sh[i] = unquantizeSH(packed.sh[i]);
+  }
+
+  result.convertCoordinates(CoordinateSystem::RUB, o.to);
+  return result;
+}
+
+void serializePackedGaussians(const PackedGaussians &packed, std::ostream *out) {
+  PackedGaussiansHeader header;
+  header.numPoints = static_cast<uint32_t>(packed.numPoints);
+  header.shDegree = static_cast<uint8_t>(packed.shDegree);
+  header.fractionalBits = static_cast<uint8_t>(packed.fractionalBits);
+  header.flags = static_cast<uint8_t>(packed.antialiased ? FlagAntialiased : 0);
+  out->write(reinterpret_cast<const char *>(&header), sizeof(header));
+  out->write(reinterpret_cast<const char *>(packed.positions.data()), countBytes(packed.positions));
+  out->write(reinterpret_cast<const char *>(packed.alphas.data()), countBytes(packed.alphas));
+  out->write(reinterpret_cast<const char *>(packed.colors.data()), countBytes(packed.colors));
+  out->write(reinterpret_cast<const char *>(packed.scales.data()), countBytes(packed.scales));
+  out->write(reinterpret_cast<const char *>(packed.rotations.data()), countBytes(packed.rotations));
+  out->write(reinterpret_cast<const char *>(packed.sh.data()), countBytes(packed.sh));
+}
+
+PackedGaussians deserializePackedGaussians(std::istream &in) {
+  constexpr int32_t maxPointsToRead = 10000000;
+
+  PackedGaussiansHeader header;
+  in.read(reinterpret_cast<char *>(&header), sizeof(header));
+  if (!in || header.magic != PackedGaussiansHeader().magic) {
+    SpzLog("[SPZ ERROR] deserializePackedGaussians: header not found");
+    return {};
+  }
+  if (header.version < 1 || header.version > 3) {
+    SpzLog("[SPZ ERROR] deserializePackedGaussians: version not supported: %d", header.version);
+    return {};
+  }
+  if (header.numPoints > maxPointsToRead) {
+    SpzLog("[SPZ ERROR] deserializePackedGaussians: Too many points: %d", header.numPoints);
+    return {};
+  }
+  if (header.shDegree > 3) {
+    SpzLog("[SPZ ERROR] deserializePackedGaussians: Unsupported SH degree: %d", header.shDegree);
+    return {};
+  }
+  const int32_t numPoints = header.numPoints;
+  const int32_t shDim = dimForDegree(header.shDegree);
+  const bool usesFloat16 = header.version == 1;
+  const bool usesQuaternionSmallestThree = header.version >= 3;
+  PackedGaussians result;
+  result.numPoints = numPoints;
+  result.shDegree = header.shDegree;
+  result.fractionalBits = header.fractionalBits;
+  result.antialiased = (header.flags & FlagAntialiased) != 0;
+  result.positions.resize(numPoints * 3 * (usesFloat16 ? 2 : 3));
+  result.scales.resize(numPoints * 3);
+  result.usesQuaternionSmallestThree = usesQuaternionSmallestThree;
+  result.rotations.resize(numPoints * (usesQuaternionSmallestThree ? 4 : 3));  
+  result.alphas.resize(numPoints);
+  result.colors.resize(numPoints * 3);
+  result.sh.resize(numPoints * shDim * 3);
+  in.read(reinterpret_cast<char *>(result.positions.data()), countBytes(result.positions));
+  in.read(reinterpret_cast<char *>(result.alphas.data()), countBytes(result.alphas));
+  in.read(reinterpret_cast<char *>(result.colors.data()), countBytes(result.colors));
+  in.read(reinterpret_cast<char *>(result.scales.data()), countBytes(result.scales));
+  in.read(reinterpret_cast<char *>(result.rotations.data()), countBytes(result.rotations));
+  in.read(reinterpret_cast<char *>(result.sh.data()), countBytes(result.sh));
+  if (!in) {
+    SpzLog("[SPZ ERROR] deserializePackedGaussians: read error");
+    return {};
+  }
+  return result;
+}
+
+bool saveSpz(const GaussianCloud &g, const PackOptions &o, std::vector<uint8_t> *out) {
+  std::string data;
+  {
+    PackedGaussians packed = packGaussians(g, o);
+    std::stringstream ss;
+    serializePackedGaussians(packed, &ss);
+    data = ss.str();
+  }
+  return compressGzipped(reinterpret_cast<const uint8_t *>(data.data()), data.size(), out);
+}
+
+PackedGaussians loadSpzPacked(const uint8_t *data, int32_t size) {
+  std::string decompressed;
+  if (!decompressGzipped(data, size, &decompressed))
+    return {};
+  std::stringstream stream(std::move(decompressed));
+  return deserializePackedGaussians(stream);
+}
+
+PackedGaussians loadSpzPacked(const std::vector<uint8_t> &data) {
+  return loadSpzPacked(data.data(), static_cast<int>(data.size()));
+}
+
+PackedGaussians loadSpzPacked(const std::string &filename) {
+  std::ifstream in(filename, std::ios::binary | std::ios::ate);
+  if (!in.good())
+    return {};
+  std::vector<uint8_t> data(in.tellg());
+  in.seekg(0, std::ios::beg);
+  in.read(reinterpret_cast<char *>(data.data()), data.size());
+  if (!in.good()) {
+    return {};
+  }
+  return loadSpzPacked(data);
+}
+
+GaussianCloud loadSpz(const std::vector<uint8_t> &data, const UnpackOptions &o) {
+  return unpackGaussians(loadSpzPacked(data), o);
+}
+
+GaussianCloud loadSpz(const uint8_t *data, int32_t size, const UnpackOptions &o) {
+  return unpackGaussians(loadSpzPacked(data, size), o);
+}
+
+bool saveSpz(const GaussianCloud &g, const PackOptions &o, const std::string &filename) {
+  std::vector<uint8_t> data;
+  if (!saveSpz(g, o, &data)) {
+    return false;
+  }
+  std::ofstream out(filename, std::ios::binary | std::ios::out);
+  out.write(reinterpret_cast<const char *>(data.data()), data.size());
+  out.close();
+  return out.good();
+}
+
+GaussianCloud loadSpz(const std::string &filename, const UnpackOptions &o) {
+  std::ifstream in(filename, std::ios::binary | std::ios::ate);
+  if (!in.good()) {
+    SpzLog("[SPZ ERROR] Unable to open: %s", filename.c_str());
+    return {};
+  }
+  std::vector<uint8_t> data(in.tellg());
+  in.seekg(0, std::ios::beg);
+  in.read(reinterpret_cast<char *>(data.data()), data.size());
+  in.close();
+  if (!in.good()) {
+    SpzLog("[SPZ ERROR] Unable to load data from: %s", filename.c_str());
+    return {};
+  }
+  return loadSpz(data, o);
+}
+
+bool getNextHeaderLine(std::ifstream &in, std::string &line) {
+  while (std::getline(in, line)) {
+    // Find the first non-whitespace character
+    size_t start = line.find_first_not_of(" \t\n\r\f\v");
+    // If line is empty or whitespace-only, skip it and continue reading.
+    if (std::string::npos == start) {
+      continue;
+    }
+    // Trim leading whitespace and check for 'comment'
+    std::string trimmed_line = line.substr(start);
+    if (trimmed_line.rfind("comment", 0) == 0) {
+      continue; // Skip comment line
+    }
+    // Found a valid non-comment, non-empty line
+    line = trimmed_line; // Update the reference string with the trimmed line
+    return true;
+  }
+  // Failed to read a line (EOF or error)
+  return false;
+}
+
+GaussianCloud loadSplatFromPly(const std::string &filename, const UnpackOptions &o) {
+  SpzLog("[SPZ] Loading: %s", filename.c_str());
+  std::ifstream in(filename, std::ios::binary);
+  if (!in.good()) {
+    SpzLog("[SPZ ERROR] Unable to open: %s", filename.c_str());
+    in.close();
+    return {};
+  }
+  std::string line;
+  std::getline(in, line);
+  if (line != "ply") {
+    SpzLog("[SPZ ERROR] %s: not a .ply file", filename.c_str());
+    in.close();
+    return {};
+  }
+  if (!getNextHeaderLine(in, line) || line != "format binary_little_endian 1.0") {
+    SpzLog("[SPZ ERROR] %s: unsupported .ply format", filename.c_str());
+    in.close();
+    return {};
+  }
+  if (!getNextHeaderLine(in, line) || line.find("element vertex ") != 0) {
+    SpzLog("[SPZ ERROR] %s: missing vertex count", filename.c_str());
+    in.close();
+    return {};
+  }
+  int32_t numPoints = std::stoi(line.substr(std::strlen("element vertex ")));
+  if (numPoints <= 0 || numPoints > 10 * 1024 * 1024) {
+    SpzLog("[SPZ ERROR] %s: invalid vertex count: %d", filename.c_str(), numPoints);
+    in.close();
+    return {};
+  }
+
+  SpzLog("[SPZ] Loading %d points", numPoints);
+  std::unordered_map<std::string, int> fields;  // name -> index
+  for (int32_t i = 0;; i++) {
+    if (!getNextHeaderLine(in, line)) {
+      SpzLog("[SPZ ERROR] %s: unexpected EOF while reading header properties.", filename.c_str());
+      in.close();
+      return {};
+    }
+    if (line == "end_header")
+      break;
+
+    if (line.find("property float ") != 0) {
+      SpzLog("[SPZ ERROR] %s: unsupported property data type: %s", filename.c_str(), line.c_str());
+      in.close();
+      return {};
+    }
+    std::string name = line.substr(std::strlen("property float "));
+    fields[name] = i;
+  }
+
+  // Returns the index for a given field name, ensuring the name exists.
+  const auto index = [&fields](const std::string &name) {
+    const auto &itr = fields.find(name);
+    if (itr == fields.end()) {
+      SpzLog("[SPZ ERROR] Missing field: %s", name.c_str());
+      return -1;
+    }
+    return itr->second;
+  };
+
+  const std::vector<int> positionIdx = {index("x"), index("y"), index("z")};
+  const std::vector<int> scaleIdx = {index("scale_0"), index("scale_1"), index("scale_2")};
+  const std::vector<int> rotIdx = {index("rot_1"), index("rot_2"), index("rot_3"), index("rot_0")};
+  const std::vector<int> alphaIdx = {index("opacity")};
+  const std::vector<int> colorIdx = {index("f_dc_0"), index("f_dc_1"), index("f_dc_2")};
+
+  // Check that only valid indices were returned.
+  for (auto idx : positionIdx) {
+    if (idx < 0) {
+      in.close();
+      return {};
+    }
+  }
+  for (auto idx : scaleIdx) {
+    if (idx < 0) {
+      in.close();
+      return {};
+    }
+  }
+  for (auto idx : rotIdx) {
+    if (idx < 0) {
+      in.close();
+      return {};
+    }
+  }
+  for (auto idx : alphaIdx) {
+    if (idx < 0) {
+      in.close();
+      return {};
+    }
+  }
+  for (auto idx : colorIdx) {
+    if (idx < 0) {
+      in.close();
+      return {};
+    }
+  }
+
+  // Spherical harmonics are optional and variable in size (depending on degree)
+  std::vector<int> shIdx;
+  for (int32_t i = 0; i < 45; i++) {
+    const auto &itr = fields.find("f_rest_" + std::to_string(i));
+    if (itr == fields.end())
+      break;
+    shIdx.push_back(itr->second);
+  }
+  const int32_t shDim = static_cast<int>(shIdx.size() / 3);
+
+  std::vector<float> values(numPoints * fields.size());
+  in.read(reinterpret_cast<char *>(values.data()), values.size() * sizeof(float));
+  if (!in.good()) {
+    SpzLog("[SPZ ERROR] Unable to load data from: %s", filename.c_str());
+    in.close();
+    return {};
+  }
+  in.close();
+
+  GaussianCloud result;
+  result.numPoints = numPoints;
+  result.shDegree = degreeForDim(shDim);
+  result.positions.reserve(numPoints * 3);
+  result.scales.reserve(numPoints * 3);
+  result.rotations.reserve(numPoints * 4);
+  result.alphas.reserve(numPoints * 1);
+  result.colors.reserve(numPoints * 3);
+  for (size_t i = 0; i < values.size(); i += fields.size()) {
+    for (int32_t j = 0; j < positionIdx.size(); j++) {
+      result.positions.push_back(values[i + positionIdx[j]]);
+    }
+    for (int32_t j = 0; j < scaleIdx.size(); j++) {
+      result.scales.push_back(values[i + scaleIdx[j]]);
+    }
+    for (int32_t j = 0; j < rotIdx.size(); j++) {
+      result.rotations.push_back(values[i + rotIdx[j]]);
+    }
+    for (int32_t j = 0; j < alphaIdx.size(); j++) {
+      result.alphas.push_back(values[i + alphaIdx[j]]);
+    }
+    for (int32_t j = 0; j < colorIdx.size(); j++) {
+      result.colors.push_back(values[i + colorIdx[j]]);
+    }
+    // Convert from [N,C,S] to [N,S,C] (where C is color channel, S is SH coeff).
+    for (int32_t j = 0; j < shDim; j++) {
+      result.sh.push_back(values[i + shIdx[j]]);
+      result.sh.push_back(values[i + shIdx[j + shDim]]);
+      result.sh.push_back(values[i + shIdx[j + 2 * shDim]]);
+    }
+  }
+
+  result.convertCoordinates(CoordinateSystem::RDF, o.to);
+  return result;
+}
+
+bool saveSplatToPly(const GaussianCloud &data, const PackOptions &o, const std::string &filename) {
+  const int32_t N = data.numPoints;
+  CHECK_EQ(data.positions.size(), N * 3);
+  CHECK_EQ(data.scales.size(), N * 3);
+  CHECK_EQ(data.rotations.size(), N * 4);
+  CHECK_EQ(data.alphas.size(), N);
+  CHECK_EQ(data.colors.size(), N * 3);
+  const int32_t shDim = static_cast<int>(data.sh.size() / N / 3);
+  const int32_t D = 17 + shDim * 3;
+
+  CoordinateConverter c = coordinateConverter(o.from, CoordinateSystem::RDF);
+
+  std::vector<float> values(N * D, 0.0f);
+  int32_t outIdx = 0, i3 = 0, i4 = 0;
+  for (int32_t i = 0; i < N; i++) {
+    // Position (x, y, z)
+    values[outIdx++] = c.flipP[0] * data.positions[i3 + 0];
+    values[outIdx++] = c.flipP[1] * data.positions[i3 + 1];
+    values[outIdx++] = c.flipP[2] * data.positions[i3 + 2];
+    // Normals (nx, ny, nz): these are always zero, but some viewers expect them to be present
+    outIdx += 3;
+    // Color (r, g, b): DC component for spherical harmonics
+    values[outIdx++] = data.colors[i3 + 0];
+    values[outIdx++] = data.colors[i3 + 1];
+    values[outIdx++] = data.colors[i3 + 2];
+    // Spherical harmonics: Interleave so the coefficients are the fastest-changing axis and
+    // the channel (r, g, b) is slower-changing axis.
+    for (int32_t j = 0; j < shDim; j++) {
+      values[outIdx++] = c.flipSh[j] * data.sh[(i * shDim + j) * 3];
+    }
+    for (int32_t j = 0; j < shDim; j++) {
+      values[outIdx++] = c.flipSh[j] * data.sh[(i * shDim + j) * 3 + 1];
+    }
+    for (int32_t j = 0; j < shDim; j++) {
+      values[outIdx++] = c.flipSh[j] * data.sh[(i * shDim + j) * 3 + 2];
+    }
+    // Alpha
+    values[outIdx++] = data.alphas[i];
+    // Scale (sx, sy, sz)
+    values[outIdx++] = data.scales[i3 + 0];
+    values[outIdx++] = data.scales[i3 + 1];
+    values[outIdx++] = data.scales[i3 + 2];
+    // Rotation (qw, qx, qy, qz)
+    values[outIdx++] = data.rotations[i4 + 3];
+    values[outIdx++] = c.flipQ[0] * data.rotations[i4 + 0];
+    values[outIdx++] = c.flipQ[1] * data.rotations[i4 + 1];
+    values[outIdx++] = c.flipQ[2] * data.rotations[i4 + 2];
+    i3 += 3;
+    i4 += 4;
+  }
+  CHECK_EQ(outIdx, values.size());
+
+  std::ofstream out(filename, std::ios::binary);
+  if (!out.good()) {
+    SpzLog("[SPZ ERROR] Unable to open for writing: %s", filename.c_str());
+    return false;
+  }
+  out << "ply\n";
+  out << "format binary_little_endian 1.0\n";
+  out << "element vertex " << N << "\n";
+  out << "property float x\n";
+  out << "property float y\n";
+  out << "property float z\n";
+  out << "property float nx\n";
+  out << "property float ny\n";
+  out << "property float nz\n";
+  out << "property float f_dc_0\n";
+  out << "property float f_dc_1\n";
+  out << "property float f_dc_2\n";
+  for (int32_t i = 0; i < shDim * 3; i++) {
+    out << "property float f_rest_" << i << "\n";
+  }
+  out << "property float opacity\n";
+  out << "property float scale_0\n";
+  out << "property float scale_1\n";
+  out << "property float scale_2\n";
+  out << "property float rot_0\n";
+  out << "property float rot_1\n";
+  out << "property float rot_2\n";
+  out << "property float rot_3\n";
+  out << "end_header\n";
+  out.write(reinterpret_cast<char *>(values.data()), values.size() * sizeof(float));
+  out.close();
+  if (!out.good()) {
+    SpzLog("[SPZ ERROR] Failed to write to: %s", filename.c_str());
+    return false;
+  }
+  return true;
+}
+
+}  // namespace spz

--- a/SPZIO/Sources/cpp/load-spz.h
+++ b/SPZIO/Sources/cpp/load-spz.h
@@ -1,0 +1,101 @@
+#pragma once
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "splat-types.h"
+
+namespace spz {
+
+// Represents a single inflated gaussian. Each gaussian has 236 bytes. Although the data is easier
+// to intepret in this format, it is not more precise than the packed format, since it was inflated.
+struct UnpackedGaussian {
+  std::array<float, 3> position;  // x, y, z
+  std::array<float, 4> rotation;  // x, y, z, w
+  std::array<float, 3> scale;     // std::log(scale)
+  std::array<float, 3> color;     // rgb sh0 encoding
+  float alpha;                    // inverse logistic
+  std::array<float, 15> shR;
+  std::array<float, 15> shG;
+  std::array<float, 15> shB;
+};
+
+// Represents a single low precision gaussian. Each gaussian has exactly 65 bytes, even if it does
+// not have full spherical harmonics.
+struct PackedGaussian {
+  std::array<uint8_t, 9> position{};
+  std::array<uint8_t, 4> rotation{};
+  std::array<uint8_t, 3> scale{};
+  std::array<uint8_t, 3> color{};
+  uint8_t alpha = 0;
+  std::array<uint8_t, 15> shR{};
+  std::array<uint8_t, 15> shG{};
+  std::array<uint8_t, 15> shB{};
+
+  UnpackedGaussian unpack(
+    bool usesFloat16,  bool usesQuaternionSmallestThree, int32_t fractionalBits, const CoordinateConverter &c) const;
+};
+
+// Represents a full splat with lower precision. Each splat has at most 64 bytes, although splats
+// with fewer spherical harmonics degrees will have less. The data is stored non-interleaved.
+struct PackedGaussians {
+  int32_t numPoints = 0;       // Total number of points (gaussians)
+  int32_t shDegree = 0;        // Degree of spherical harmonics
+  int32_t fractionalBits = 0;  // Number of bits used for fractional part of fixed-point coords
+  bool antialiased = false;    // Whether gaussians should be rendered with mip-splat antialiasing
+  bool usesQuaternionSmallestThree = true; // Whether gaussians use the smallest three method to store quaternions
+
+  std::vector<uint8_t> positions;
+  std::vector<uint8_t> scales;
+  std::vector<uint8_t> rotations;
+  std::vector<uint8_t> alphas;
+  std::vector<uint8_t> colors;
+  std::vector<uint8_t> sh;
+
+  bool usesFloat16() const;
+  PackedGaussian at(int32_t i) const;
+  UnpackedGaussian unpack(int32_t i, const CoordinateConverter &c) const;
+};
+
+struct PackOptions {
+  CoordinateSystem from = CoordinateSystem::UNSPECIFIED;
+};
+
+struct UnpackOptions {
+  CoordinateSystem to = CoordinateSystem::UNSPECIFIED;
+};
+
+// Saves Gaussian splat in packed format, returning a vector of bytes.
+bool saveSpz(
+  const GaussianCloud &gaussians, const PackOptions &options, std::vector<uint8_t> *output);
+
+// Loads Gaussian splat from a vector of bytes in packed format.
+GaussianCloud loadSpz(const std::vector<uint8_t> &data, const UnpackOptions &options);
+
+// Loads Gaussian splat from a vector of bytes in packed format.
+PackedGaussians loadSpzPacked(const std::string &filename);
+PackedGaussians loadSpzPacked(const uint8_t *data, int32_t size);
+PackedGaussians loadSpzPacked(const std::vector<uint8_t> &data);
+
+// Saves Gaussian splat in packed format to a file
+bool saveSpz(
+  const GaussianCloud &gaussians, const PackOptions &options, const std::string &filename);
+
+// Loads Gaussian splat from a file in packed format
+GaussianCloud loadSpz(const std::string &filename, const UnpackOptions &o);
+
+// Loads Gaussian splat from a byte pointer in packed format.
+GaussianCloud loadSpz(const uint8_t *data, int32_t size, const UnpackOptions &options);
+
+// Saves Gaussian splat data in .ply format
+bool saveSplatToPly(
+  const spz::GaussianCloud &gaussians, const PackOptions &options, const std::string &filename);
+
+// Loads Gaussian splat data in .ply format
+GaussianCloud loadSplatFromPly(const std::string &filename, const UnpackOptions &options);
+
+void serializePackedGaussians(const PackedGaussians &packed, std::ostream *out);
+
+bool compressGzipped(const uint8_t *data, size_t size, std::vector<uint8_t> *out);
+}  // namespace spz

--- a/SPZIO/Sources/cpp/splat-c-types.cc
+++ b/SPZIO/Sources/cpp/splat-c-types.cc
@@ -1,0 +1,3 @@
+#include "splat-c-types.h"
+
+// Empty.

--- a/SPZIO/Sources/cpp/splat-c-types.h
+++ b/SPZIO/Sources/cpp/splat-c-types.h
@@ -1,0 +1,28 @@
+#ifndef SPZ_SPLAT_C_TYPES_H_
+#define SPZ_SPLAT_C_TYPES_H_
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// These types are used to bridge between the C++ API and C (to interop with Swift and C#).
+
+typedef struct {
+  size_t count;
+  float *data;
+} SpzFloatBuffer;
+
+typedef struct {
+  int32_t numPoints;
+  int32_t shDegree;
+  bool antialiased;
+  SpzFloatBuffer positions;
+  SpzFloatBuffer scales;
+  SpzFloatBuffer rotations;
+  SpzFloatBuffer alphas;
+  SpzFloatBuffer colors;
+  SpzFloatBuffer sh;
+} GaussianCloudData;
+
+#endif  // SPZ_SPLAT_C_TYPES_H_

--- a/SPZIO/Sources/cpp/splat-types.cc
+++ b/SPZIO/Sources/cpp/splat-types.cc
@@ -1,0 +1,98 @@
+#include "splat-types.h"
+
+#include <cmath>
+#include <limits>
+
+namespace spz {
+
+float halfToFloat(Half h) {
+  auto sgn = ((h >> 15) & 0x1);
+  auto exponent = ((h >> 10) & 0x1f);
+  auto mantissa = h & 0x3ff;
+
+  float signMul = sgn == 1 ? -1.0 : 1.0;
+  if (exponent == 0) {
+    // Subnormal numbers (no exponent, 0 in the mantissa decimal).
+    return signMul * std::pow(2.0f, -14.0f) * static_cast<float>(mantissa) / 1024.0f;
+  }
+
+  if (exponent == 31) {
+    // Infinity or NaN.
+    return mantissa != 0 ? std::numeric_limits<float>::quiet_NaN() : signMul * std::numeric_limits<float>::infinity();
+  }
+
+  // non-zero exponent implies 1 in the mantissa decimal.
+  return signMul * std::pow(2.0f, static_cast<float>(exponent) - 15.0f)
+    * (1.0f + static_cast<float>(mantissa) / 1024.0f);
+}
+
+Half floatToHalf(float f) {
+  uint32_t f32 = *reinterpret_cast<uint32_t *>(&f);
+  int32_t sign = (f32 >> 31) & 0x01;        // 1 bit   -> 1 bit
+  int32_t exponent = ((f32 >> 23) & 0xff);  // 8 bits  -> 5 bits
+  int32_t mantissa = f32 & 0x7fffff;        // 23 bits -> 10 bits
+
+  // Handle inf and nan from float.
+  if (exponent == 0xFF) {
+    if (mantissa == 0) {
+      return (sign << 15) | 0x7C00; // Inf
+    }
+
+    return (sign << 15) | 0x7C01;  // Nan
+  }
+
+  // If the exponent is greater than the range of half, return +/- Inf.
+  int32_t centeredExp = exponent - 127;
+  if (centeredExp > 15) {
+    return (sign << 15) | 0x7C00;
+  }
+
+  // Normal numbers. centeredExp = [-15, 15]
+  if (centeredExp > -15) {
+    return (sign << 15) | ((centeredExp + 15) << 10) | (mantissa >> 13);
+  }
+
+  // Subnormal numbers.
+  int32_t fullMantissa = 0x800000 | mantissa;
+  int32_t shift = -(centeredExp + 14);  // Shift is in [-1 to -113]
+  int32_t newMantissa = fullMantissa >> shift;
+  return (sign << 15) | (newMantissa >> 13);
+}
+
+float norm(const Vec3f &a) {
+  return std::sqrt(squaredNorm(a));
+}
+
+Vec3f normalized(const Vec3f &v) {
+  float n = norm(v);
+  return {v[0] / n, v[1] / n, v[2] / n};
+}
+
+Quat4f normalized(const Quat4f &v) {
+  float norm = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3]);
+  return {v[0] / norm, v[1] / norm, v[2] / norm, v[3] / norm};
+}
+
+float norm(const Quat4f &q) {
+  return std::sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+}
+
+Quat4f axisAngleQuat(const Vec3f &scaledAxis) {
+  const float &a0 = scaledAxis[0];
+  const float &a1 = scaledAxis[1];
+  const float &a2 = scaledAxis[2];
+  const float thetaSquared = a0 * a0 + a1 * a1 + a2 * a2;
+  // For points not at the origin, the full conversion is numerically stable.
+  if (thetaSquared > 0.0f) {
+    const float theta = std::sqrt(thetaSquared);
+    const float halfTheta = theta * 0.5f;
+    const float k = std::sin(halfTheta) / theta;
+    return normalized(std::array<float, 4>{std::cos(halfTheta), a0 * k, a1 * k, a2 * k});
+  }
+  // If thetaSquared is 0, then we will get NaNs when dividing by theta.  By approximating with a
+  // Taylor series, and truncating at one term, the value will be computed correctly.
+  const float k = 0.5f;
+  return normalized(Quat4f{1.0f, a0 * k, a1 * k, a2 * k});
+}
+
+}  // namespace spz

--- a/SPZIO/Sources/cpp/splat-types.h
+++ b/SPZIO/Sources/cpp/splat-types.h
@@ -1,0 +1,266 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "splat-c-types.h"
+
+namespace spz {
+
+inline SpzFloatBuffer copyFloatBuffer(const std::vector<float> &vector) {
+  SpzFloatBuffer buffer = {0, nullptr};
+  if (!vector.empty()) {
+    buffer.count = vector.size();
+    buffer.data = new float[buffer.count];
+    std::memcpy(buffer.data, vector.data(), buffer.count * sizeof(float));
+  }
+  return buffer;
+}
+
+enum class CoordinateSystem {
+  UNSPECIFIED = 0,
+  LDB = 1,  // Left Down Back
+  RDB = 2,  // Right Down Back
+  LUB = 3,  // Left Up Back
+  RUB = 4,  // Right Up Back, Three.js coordinate system
+  LDF = 5,  // Left Down Front
+  RDF = 6,  // Right Down Front, PLY coordinate system
+  LUF = 7,  // Left Up Front, GLB coordinate system
+  RUF = 8,  // Right Up Front, Unity coordinate system
+};
+
+struct CoordinateConverter {
+  std::array<float, 3> flipP = {1.0f, 1.0f, 1.0f};  // x, y, z flips.
+  std::array<float, 3> flipQ = {1.0f, 1.0f, 1.0f};  // x, y, z flips, w is never flipped.
+  std::array<float, 15> flipSh =  // Flips for the 15 spherical harmonics coefficients.
+    {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+};
+
+constexpr std::array<bool, 3> axesMatch(CoordinateSystem a, CoordinateSystem b) {
+  auto aNum = static_cast<int>(a) - 1;
+  auto bNum = static_cast<int>(b) - 1;
+  if (aNum < 0 || bNum < 0) {
+    return {true, true, true};
+  }
+  return {
+    ((aNum >> 0) & 1) == ((bNum >> 0) & 1),
+    ((aNum >> 1) & 1) == ((bNum >> 1) & 1),
+    ((aNum >> 2) & 1) == ((bNum >> 2) & 1)};
+}
+
+constexpr CoordinateConverter coordinateConverter(CoordinateSystem from, CoordinateSystem to) {
+  auto [xMatch, yMatch, zMatch] = axesMatch(from, to);
+  float x = xMatch ? 1.0f : -1.0f;
+  float y = yMatch ? 1.0f : -1.0f;
+  float z = zMatch ? 1.0f : -1.0f;
+  return CoordinateConverter{
+    {x, y, z},
+    {y * z, x * z, x * y},
+    {
+      y,          // 0
+      z,          // 1
+      x,          // 2
+      x * y,      // 3
+      y * z,      // 4
+      1.0f,       // 5
+      x * z,      // 6
+      1.0f,       // 7
+      y,          // 8
+      x * y * z,  // 9
+      y,          // 10
+      z,          // 11
+      x,          // 12
+      z,          // 13
+      x           // 14
+    }
+  };
+}
+
+// A point cloud composed of Gaussians. Each gaussian is represented by:
+//   - xyz position
+//   - xyz scales (on log scale, compute exp(x) to get scale factor)
+//   - xyzw quaternion
+//   - alpha (before sigmoid activation, compute sigmoid(a) to get alpha value between 0 and 1)
+//   - rgb color (as SH DC component, compute 0.5 + 0.282095 * x to get color value between 0 and 1)
+//   - 0 to 45 spherical harmonics coefficients (see comment below)
+struct GaussianCloud {
+  // Total number of points (gaussians) in this splat.
+  int32_t numPoints = 0;
+
+  // Degree of spherical harmonics for this splat.
+  int32_t shDegree = 0;
+
+  // Whether the gaussians should be rendered in antialiased mode (mip splatting)
+  bool antialiased = false;
+
+  // See block comment above for details
+  std::vector<float> positions;
+  std::vector<float> scales;
+  std::vector<float> rotations;
+  std::vector<float> alphas;
+  std::vector<float> colors;
+
+  // Spherical harmonics coefficients. The number of coefficients per point depends on shDegree:
+  //   0 -> 0
+  //   1 -> 9   (3 coeffs x 3 channels)
+  //   2 -> 24  (8 coeffs x 3 channels)
+  //   3 -> 45  (15 coeffs x 3 channels)
+  // The color channel is the inner (fastest varying) axis, and the coefficient is the outer
+  // (slower varying) axis, i.e. for degree 1, the order of the 9 values is:
+  //   sh1n1_r, sh1n1_g, sh1n1_b, sh10_r, sh10_g, sh10_b, sh1p1_r, sh1p1_g, sh1p1_b
+  std::vector<float> sh;
+
+  // The caller is responsible for freeing the pointers in the returned GaussianCloudData
+  GaussianCloudData data() const {
+    GaussianCloudData data;
+    data.numPoints = numPoints;
+    data.shDegree = shDegree;
+    data.antialiased = antialiased;
+    data.positions = copyFloatBuffer(positions);
+    data.scales = copyFloatBuffer(scales);
+    data.rotations = copyFloatBuffer(rotations);
+    data.alphas = copyFloatBuffer(alphas);
+    data.colors = copyFloatBuffer(colors);
+    data.sh = copyFloatBuffer(sh);
+    return data;
+  }
+
+  // Convert between two coordinate systems, for example from RDF (ply format) to RUB (used by spz).
+  // This is performed in-place.
+  void convertCoordinates(CoordinateSystem from, CoordinateSystem to) {
+    if (numPoints == 0) {
+      // There is nothing to convert.
+      return;
+    }
+    CoordinateConverter c = coordinateConverter(from, to);
+    for (size_t i = 0; i < positions.size(); i += 3) {
+      positions[i + 0] *= c.flipP[0];
+      positions[i + 1] *= c.flipP[1];
+      positions[i + 2] *= c.flipP[2];
+    }
+    for (size_t i = 0; i < rotations.size(); i += 4) {
+      rotations[i + 0] *= c.flipQ[0];
+      rotations[i + 1] *= c.flipQ[1];
+      rotations[i + 2] *= c.flipQ[2];
+      // Don't modify rotations[i + 3] (w component)
+    }
+    // Rotate spherical harmonics by inverting coefficients that reference the y and z axes, for
+    // each RGB channel. See spherical_harmonics_kernel_impl.h for spherical harmonics formulas.
+    const size_t numCoeffs = sh.size() / 3;
+    const size_t numCoeffsPerPoint = numCoeffs / numPoints;
+    size_t idx = 0;
+    for (size_t i = 0; i < numCoeffs; i += numCoeffsPerPoint) {
+      for (size_t j = 0; j < numCoeffsPerPoint; ++j, idx += 3) {
+        auto flip = c.flipSh[j];
+        sh[idx + 0] *= flip;
+        sh[idx + 1] *= flip;
+        sh[idx + 2] *= flip;
+      }
+    }
+  }
+
+  // Rotates the GaussianCloud by 180 degrees about the x axis (converts from RUB to RDF coordinates
+  // and vice versa. This is performed in-place.
+  void rotate180DegAboutX() { convertCoordinates(CoordinateSystem::RUB, CoordinateSystem::RDF); }
+
+  float medianVolume() const {
+    if (numPoints == 0) {
+      return 0.01f;
+    }
+    // The volume of an ellipsoid is 4/3 * pi * x * y * z, where x, y, and z are the radii on each
+    // axis. Scales are stored on a log scale, and exp(x) * exp(y) * exp(z) = exp(x + y + z). So we
+    // can sort by value = (x + y + z) and compute volume = 4/3 * pi * exp(value) later.
+    std::vector<float> scaleSums;
+    for (size_t i = 0; i < scales.size(); i += 3) {
+      float sum = scales[i] + scales[i + 1] + scales[i + 2];
+      scaleSums.push_back(sum);
+    }
+    std::sort(scaleSums.begin(), scaleSums.end());
+    float median = scaleSums[scaleSums.size() / 2];
+    return (M_PI * 4 / 3) * exp(median);
+  }
+};
+
+// SPZ Splat math helpers, lightweight implementations of vector and quaternion math.
+using Vec3f = std::array<float, 3>;   // x, y, z
+using Quat4f = std::array<float, 4>;  // w, x, y, z
+using Half = uint16_t;
+
+// Half-precision helpers.
+float halfToFloat(Half h);
+Half floatToHalf(float f);
+
+// Vector helpers.
+Vec3f normalized(const Vec3f &v);
+float norm(const Vec3f &a);
+
+// Quaternion helpers.
+float norm(const Quat4f &q);
+Quat4f normalized(const Quat4f &v);
+Quat4f axisAngleQuat(const Vec3f &scaledAxis);
+
+// Constexpr helpers.
+constexpr Vec3f vec3f(const float *data) { return {data[0], data[1], data[2]}; }
+
+constexpr float dot(const Vec3f &a, const Vec3f &b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+constexpr float squaredNorm(const Vec3f &v) { return dot(v, v); }
+
+constexpr Quat4f quat4f(const float *data) { return {data[0], data[1], data[2], data[3]}; }
+
+constexpr Vec3f times(const Quat4f &q, const Vec3f &p) {
+  auto [w, x, y, z] = q;
+  auto [vx, vy, vz] = p;
+  auto x2 = x + x;
+  auto y2 = y + y;
+  auto z2 = z + z;
+  auto wx2 = w * x2;
+  auto wy2 = w * y2;
+  auto wz2 = w * z2;
+  auto xx2 = x * x2;
+  auto xy2 = x * y2;
+  auto xz2 = x * z2;
+  auto yy2 = y * y2;
+  auto yz2 = y * z2;
+  auto zz2 = z * z2;
+  return {
+    vx * (1.0f - (yy2 + zz2)) + vy * (xy2 - wz2) + vz * (xz2 + wy2),
+    vx * (xy2 + wz2) + vy * (1.0f - (xx2 + zz2)) + vz * (yz2 - wx2),
+    vx * (xz2 - wy2) + vy * (yz2 + wx2) + vz * (1.0f - (xx2 + yy2))};
+}
+
+inline Quat4f times(const Quat4f &a, const Quat4f &b) {
+  auto [w, x, y, z] = a;
+  auto [qw, qx, qy, qz] = b;
+  return normalized(std::array<float, 4>{
+    w * qw - x * qx - y * qy - z * qz,
+    w * qx + x * qw + y * qz - z * qy,
+    w * qy - x * qz + y * qw + z * qx,
+    w * qz + x * qy - y * qx + z * qw});
+}
+
+constexpr Quat4f times(const Quat4f &a, float s) {
+  return {a[0] * s, a[1] * s, a[2] * s, a[3] * s};
+}
+
+constexpr Quat4f plus(const Quat4f &a, const Quat4f &b) {
+  return {a[0] + b[0], a[1] + b[1], a[2] + b[2], a[3] + b[3]};
+}
+
+constexpr Vec3f times(const Vec3f &v, float s) { return {v[0] * s, v[1] * s, v[2] * s}; }
+
+constexpr Vec3f plus(const Vec3f &a, const Vec3f &b) {
+  return {a[0] + b[0], a[1] + b[1], a[2] + b[2]};
+}
+
+constexpr Vec3f times(const Vec3f &a, const Vec3f &b) {
+  return {a[0] * b[0], a[1] * b[1], a[2] * b[2]};
+}
+
+}  // namespace spz

--- a/SPZIO/Sources/include/SPZReader.h
+++ b/SPZIO/Sources/include/SPZReader.h
@@ -1,0 +1,48 @@
+#import <Foundation/Foundation.h>
+#import <simd/simd.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A structure representing a single Gaussian point loaded from an SPZ file
+typedef struct {
+    simd_float3 position;
+    simd_float4 rotation; // quaternion (w, x, y, z)
+    simd_float3 scale;    // log scale
+    simd_float3 color;    // SH DC component
+    float alpha;          // logit alpha
+    int32_t shDegree;     // degree of spherical harmonics for this point
+} SPZGaussianPoint;
+
+/// A block that receives batches of Gaussian points during streaming
+typedef void (^SPZPointBatchHandler)(const SPZGaussianPoint *points, NSUInteger count);
+
+/// Objective-C wrapper for SPZ file loading
+@interface SPZReader : NSObject
+
+/// Load an SPZ file and call the handler for each batch of points
+/// @param url The URL of the SPZ file to load
+/// @param handler Block called with batches of points during loading
+/// @param error Error pointer for failure cases
+/// @return YES on success, NO on failure
++ (BOOL)loadSPZFileAtURL:(NSURL *)url
+         batchHandler:(SPZPointBatchHandler)handler
+                error:(NSError **)error;
+
+/// Load SPZ data from memory and call the handler for each batch of points
+/// @param data The SPZ data to load
+/// @param handler Block called with batches of points during loading
+/// @param error Error pointer for failure cases
+/// @return YES on success, NO on failure
++ (BOOL)loadSPZData:(NSData *)data
+       batchHandler:(SPZPointBatchHandler)handler
+              error:(NSError **)error;
+
+/// Get the total number of points in an SPZ file without loading all data
+/// @param url The URL of the SPZ file
+/// @param error Error pointer for failure cases
+/// @return The number of points, or 0 on error
++ (NSUInteger)pointCountInFileAtURL:(NSURL *)url error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SampleApp/Scene/ContentView.swift
+++ b/SampleApp/Scene/ContentView.swift
@@ -69,6 +69,7 @@ struct ContentView: View {
                           allowedContentTypes: [
                             UTType(filenameExtension: "ply")!,
                             UTType(filenameExtension: "splat")!,
+                            UTType(filenameExtension: "spz")!,
                           ]) {
                 isPickingFile = false
                 switch $0 {

--- a/SampleApp/Scene/VisionSceneRenderer.swift
+++ b/SampleApp/Scene/VisionSceneRenderer.swift
@@ -98,19 +98,13 @@ class VisionSceneRenderer {
 
         let simdDeviceAnchor = deviceAnchor?.originFromAnchorTransform ?? matrix_identity_float4x4
 
-        return drawable.views.map { view in
+        return drawable.views.enumerated().map { (index, view) in
             let userViewpointMatrix = (simdDeviceAnchor * view.transform).inverse
-            let projectionMatrix = ProjectiveTransform3D(leftTangent: Double(view.tangents[0]),
-                                                         rightTangent: Double(view.tangents[1]),
-                                                         topTangent: Double(view.tangents[2]),
-                                                         bottomTangent: Double(view.tangents[3]),
-                                                         nearZ: Double(drawable.depthRange.y),
-                                                         farZ: Double(drawable.depthRange.x),
-                                                         reverseZ: true)
+            let projectionMatrix = drawable.computeProjection(viewIndex: index)
             let screenSize = SIMD2(x: Int(view.textureMap.viewport.width),
                                    y: Int(view.textureMap.viewport.height))
             return ModelRendererViewportDescriptor(viewport: view.textureMap.viewport,
-                                                   projectionMatrix: .init(projectionMatrix),
+                                                   projectionMatrix: projectionMatrix,
                                                    viewMatrix: userViewpointMatrix * translationMatrix * rotationMatrix * commonUpCalibration,
                                                    screenSize: screenSize)
         }
@@ -155,7 +149,7 @@ class VisionSceneRenderer {
             semaphore.signal()
         }
 
-        updateRotation()
+       updateRotation()
 
         let viewports = self.viewports(drawable: drawable, deviceAnchor: deviceAnchor)
 

--- a/SplatConverter/Sources/SplatConverter.swift
+++ b/SplatConverter/Sources/SplatConverter.swift
@@ -194,6 +194,7 @@ enum SplatOutputFileFormat: ExpressibleByArgument {
         switch format {
         case .dotSplat: self = .dotSplat
         case .ply: self = .binaryPLY
+        case .spz: return nil // SPZ is read-only, no conversion output
         case .none: return nil
         }
     }

--- a/SplatIO/Sources/AutodetectSceneReader.swift
+++ b/SplatIO/Sources/AutodetectSceneReader.swift
@@ -11,6 +11,7 @@ public class AutodetectSceneReader: SplatSceneReader {
         switch SplatFileFormat(for: url) {
         case .ply: reader = try SplatPLYSceneReader(url)
         case .dotSplat: reader = try DotSplatSceneReader(url)
+        case .spz: reader = try SPZSceneReader(url)
         case .none: throw Error.cannotDetermineFormat
         }
     }

--- a/SplatIO/Sources/SPZSceneReader.swift
+++ b/SplatIO/Sources/SPZSceneReader.swift
@@ -1,0 +1,101 @@
+import Foundation
+import SPZIO
+import simd
+
+/// A reader for Gaussian Splat files in the compressed .spz format
+public class SPZSceneReader: SplatSceneReader {
+    public enum Error: Swift.Error, LocalizedError {
+        case cannotOpenSource(URL)
+        case loadFailed(String)
+        case invalidData
+
+        public var errorDescription: String? {
+            switch self {
+            case .cannotOpenSource(let url):
+                "Cannot open SPZ file at \(url.path)"
+            case .loadFailed(let message):
+                "Failed to load SPZ file: \(message)"
+            case .invalidData:
+                "Invalid SPZ data"
+            }
+        }
+    }
+
+    private let url: URL
+
+    public init(_ url: URL) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw Error.cannotOpenSource(url)
+        }
+        self.url = url
+    }
+
+    public func read(to delegate: any SplatSceneReaderDelegate) {
+        // Try to get point count first for progress reporting
+        var nsError: NSError?
+        let pointCount = SPZReader.pointCountInFile(at: url, error: &nsError)
+
+        if let error = nsError {
+            delegate.didFailReading(withError: Error.loadFailed(error.localizedDescription))
+            return
+        }
+
+        delegate.didStartReading(withPointCount: pointCount > 0 ? UInt32(pointCount) : nil)
+
+        // Load the SPZ file with batch processing
+        do {
+            try SPZReader.loadSPZFile(at: url, batchHandler: { (points, count) in
+                let splatPoints = self.convertPoints(points, count: count)
+                delegate.didRead(points: splatPoints)
+            })
+            delegate.didFinishReading()
+        } catch {
+            delegate.didFailReading(withError: Error.loadFailed(error.localizedDescription))
+        }
+    }
+
+    private func convertPoints(_ points: UnsafePointer<SPZGaussianPoint>?, count: UInt) -> [SplatScenePoint] {
+        guard let points = points else { return [] }
+
+        var result: [SplatScenePoint] = []
+        result.reserveCapacity(Int(count))
+
+        for i in 0..<Int(count) {
+            let spzPoint = points[i]
+
+            // Convert position (already in correct coordinate system)
+            let position = spzPoint.position
+
+            // Convert rotation quaternion from (w, x, y, z) to simd_quatf
+            // SPZ stores as (w, x, y, z), simd_quatf expects (x, y, z, w) in vector form
+            let rotation = simd_quatf(
+                ix: spzPoint.rotation.y,
+                iy: spzPoint.rotation.z,
+                iz: spzPoint.rotation.w,
+                r: spzPoint.rotation.x
+            )
+
+            // Convert scale from log scale to exponent format
+            let scale = SplatScenePoint.Scale.exponent(spzPoint.scale)
+
+            // Convert color from SH DC component
+            // SPZ stores the raw SH coefficient, we pass it through as spherical harmonic
+            let color = SplatScenePoint.Color.sphericalHarmonic([spzPoint.color])
+
+            // Convert alpha from logit format
+            let opacity = SplatScenePoint.Opacity.logitFloat(spzPoint.alpha)
+
+            let point = SplatScenePoint(
+                position: position,
+                color: color,
+                opacity: opacity,
+                scale: scale,
+                rotation: rotation
+            )
+
+            result.append(point)
+        }
+
+        return result
+    }
+}

--- a/SplatIO/Sources/SplatFileFormat.swift
+++ b/SplatIO/Sources/SplatFileFormat.swift
@@ -3,11 +3,13 @@ import Foundation
 public enum SplatFileFormat {
     case ply
     case dotSplat
+    case spz
 
     public init?(for url: URL) {
         switch url.pathExtension.lowercased() {
         case "ply": self = .ply
         case "splat": self = .dotSplat
+        case "spz": self = .spz
         default: return nil
         }
     }


### PR DESCRIPTION
- Introduced new header and source files for SPZ file handling in SPZIO, including structures for unpacked and packed gaussians.
- Implemented loading functions for SPZ files, including support for reading from memory and files.
- Added Objective-C interface for SPZ file loading, allowing integration with Swift and C++.
- Updated existing Swift files to recognize and handle SPZ file format in the autodetect scene reader and file format enumeration.
- Enhanced the SplatConverter to prevent output conversion for SPZ files, as they are read-only.
- Implemented SPZSceneReader for reading Gaussian splat data from SPZ files, including error handling and point conversion.