### PR TITLE
Fix: Skip non-vertex PLY elements instead of throwing

### DIFF
--- a/SplatIO/Sources/SplatPLYSceneReader.swift
+++ b/SplatIO/Sources/SplatPLYSceneReader.swift
@@ -48,9 +48,9 @@ public class SplatPLYSceneReader: SplatSceneReader {
 
                 for try await plyStreamElementSeries in plyStream {
                     var pointCount = 0
+                    // Skip non-vertex element types (e.g. face, extrinsic, intrinsic metadata)
                     guard plyStreamElementSeries.typeIndex == elementMapping.elementTypeIndex else {
-                        continuation.finish(throwing: Error.unsupportedFileContents("Expected type index \(elementMapping.elementTypeIndex), found \(plyStreamElementSeries.typeIndex)"))
-                        return
+                        continue
                     }
 
                     do {


### PR DESCRIPTION
## Problem

PLY files from tools like [ml-sharp](https://github.com/nerfstudio-project/nerfstudio) include extra metadata elements alongside vertex data:

```
element vertex 1179648
property float x
...
element extrinsic 16
property float extrinsic
element intrinsic 9
property float intrinsic
element image_size 2
property uint image_size
```

`SplatPLYSceneReader.read()` throws `unsupportedFileContents("Expected type index 0, found 1")` when it encounters these non-vertex elements in the async stream, instead of skipping them.

## Fix

Changed the guard clause in `SplatPLYSceneReader.swift:51` from throwing an error to `continue`, so non-vertex element types are silently skipped.

## Testing

Tested with ml-sharp PLY files containing 8 element types (vertex, extrinsic, intrinsic, image_size, frame, disparity, color_space, version). Vertex data loads correctly, metadata elements are skipped.